### PR TITLE
Default booking simulation

### DIFF
--- a/src/test/scala/adele/DefaultBookingSimulation.scala
+++ b/src/test/scala/adele/DefaultBookingSimulation.scala
@@ -12,7 +12,8 @@ class DefaultBookingSimulation extends Simulation {
 
     private final val Random = new Random(1)
 
-    private final val BaseUrl = "http://localhost:8080"
+    private final val HttpBaseUrl = "http://localhost:8080"
+    private final val WsBaseUrl = "ws://localhost:8080/ws"
 
     private final val MinimumNumberOfBookedTickets = 2
     private final val MaximumNumberOfBookedTickets = 5
@@ -26,7 +27,7 @@ class DefaultBookingSimulation extends Simulation {
     val httpConf = http
             .disableWarmUp // no GET request for http://gatling.io in the beginning
             .perUserNameResolution // needed if additional instances are added during load test
-            .baseURL(BaseUrl)
+            .baseURL(HttpBaseUrl)
             .acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
             .acceptEncodingHeader("gzip, deflate")
             .acceptLanguageHeader("en-US,en;q=0.5")
@@ -42,12 +43,12 @@ class DefaultBookingSimulation extends Simulation {
             .feed(feeder)
 
             // Home Page
-            .exec(http("get_events").get("/rs/api/events"))
+            .exec(http("HTTP get_events").get("/rs/api/events"))
             .pause(5)
 
             // First Event selected
             .exec(ws("WS Open")
-                .open("ws://localhost:8080/ws"))
+                .open(WsBaseUrl))
             .pause(1)
             .exec(ws("WS Send connect")
                     .sendText(Stomp.StompConnect)
@@ -63,7 +64,6 @@ class DefaultBookingSimulation extends Simulation {
             .pause(10)
 
             // Book selected tickets
-            // todo repeat until session has bookingId
             .exec(http("HTTP booking_request")
                     .post("/bookings")
                     .body(StringBody("""${REQUEST}""")).asJSON

--- a/src/test/scala/adele/DefaultBookingSimulation.scala
+++ b/src/test/scala/adele/DefaultBookingSimulation.scala
@@ -3,11 +3,14 @@ package adele
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 
+import scala.collection.parallel.mutable.ParHashMap
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
 import scala.util.Random
 
 class DefaultBookingSimulation extends Simulation {
+
+    private final val Random = new Random(1)
 
     private final val BaseUrl = "http://localhost:8080"
 
@@ -15,6 +18,10 @@ class DefaultBookingSimulation extends Simulation {
     private final val MaximumNumberOfBookedTickets = 5
     private final val NumberOfSectors = 50
     private final val SectorSize = 250
+
+    // Init ticket map
+    private final val TicketMap: ParHashMap[Int, Int] = ParHashMap()
+    (1 to NumberOfSectors).foreach(sector => TicketMap += (sector -> 0))
 
     val httpConf = http
             .disableWarmUp // no GET request for http://gatling.io in the beginning
@@ -27,8 +34,7 @@ class DefaultBookingSimulation extends Simulation {
 
     val feeder = Iterator.continually(
         Map(
-            "SECTOR" -> generateSector(),
-            "POSITIONS" -> generatePositions().mkString(",")
+            "REQUEST" -> generateRequest()
         )
     )
 
@@ -60,7 +66,7 @@ class DefaultBookingSimulation extends Simulation {
             // todo repeat until session has bookingId
             .exec(http("HTTP booking_request")
                     .post("/bookings")
-                    .body(StringBody("""{"eventId": 1, "sectorId": ${SECTOR}, "positions": [${POSITIONS}]}""")).asJSON
+                    .body(StringBody("""${REQUEST}""")).asJSON
                     .check(jsonPath("$.bookingId").optional.saveAs("bookingId")))
             .pause(5)
 
@@ -71,25 +77,40 @@ class DefaultBookingSimulation extends Simulation {
             // Pay the tickets
 
     setUp(
-        defaultBooking.inject(rampUsers(1000) over new DurationInt(1).minutes).protocols(httpConf)
+        defaultBooking.inject(rampUsers(4000) over new DurationInt(5).minutes).protocols(httpConf)
     ).assertions(
-        global.responseTime.max.lt(800),
+        global.responseTime.max.lt(2000),
         global.successfulRequests.percent.is(100)
     )
 
+    def generateRequest(): String = {
+        val sector = generateSector()
+        val positions = generatePositions(sector)
+
+        "{\"eventId\": 1, \"sectorId\": " + sector + ", \"positions\": [" + positions.mkString(",") + "]}"
+    }
+
     def generateSector(): Int = {
-        Random.nextInt(NumberOfSectors) + 1
+        var sector = 0
+        var maxTry = 10
+
+        do {
+            sector = Random.nextInt(NumberOfSectors) + 1
+            maxTry -= 1
+        } while (TicketMap(sector) >= SectorSize || maxTry <= 0)
+
+        sector
     }
 
     /**
-      * Returns a random range of positions based on the minimum and maximum number of tickets to be booked
+      * Returns a Random range of positions based on the minimum and maximum number of tickets to be booked
       * e.g.: Range(5, 6, 7, 8)
       */
-    def generatePositions(): Range = {
-        val r = Random
-        val numberOfTickets = math.max(MinimumNumberOfBookedTickets, r.nextInt(MaximumNumberOfBookedTickets + 1))
-        val startingPosition = r.nextInt(SectorSize - numberOfTickets + 1)
-        val endPosition = startingPosition + numberOfTickets - 1
+    def generatePositions(sector: Int): Range = {
+        val numberOfTickets = math.max(MinimumNumberOfBookedTickets, Random.nextInt(MaximumNumberOfBookedTickets + 1))
+        val startingPosition = TicketMap(sector) + 1
+        val endPosition = math.min(startingPosition + numberOfTickets - 1, SectorSize)
+        TicketMap += (sector -> endPosition)
         startingPosition to endPosition
     }
 

--- a/src/test/scala/adele/DefaultBookingSimulation.scala
+++ b/src/test/scala/adele/DefaultBookingSimulation.scala
@@ -3,6 +3,8 @@ package adele
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
 import scala.util.Random
 
 class DefaultBookingSimulation extends Simulation {
@@ -11,7 +13,7 @@ class DefaultBookingSimulation extends Simulation {
 
     private final val MinimumNumberOfBookedTickets = 2
     private final val MaximumNumberOfBookedTickets = 10
-    private final val NumberOfSectors = 3
+    private final val NumberOfSectors = 50
     private final val SectorSize = 250
 
     val httpConf = http
@@ -45,7 +47,7 @@ class DefaultBookingSimulation extends Simulation {
                     .post("/bookings")
                     .body(StringBody("""{"eventId": 1, "sectorId": ${SECTOR}, "positions": [${POSITIONS}]}""")).asJSON)
 
-    setUp(scn.inject(atOnceUsers(200)).protocols(httpConf))
+    setUp(scn.inject(rampUsers(2000) over new DurationInt(2).minutes).protocols(httpConf))
 
     def generateSector(): Int = {
         Random.nextInt(NumberOfSectors) + 1

--- a/src/test/scala/adele/DefaultBookingSimulation.scala
+++ b/src/test/scala/adele/DefaultBookingSimulation.scala
@@ -1,0 +1,32 @@
+package adele
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+class DefaultBookingSimulation extends Simulation {
+
+    val httpConf = http
+            .baseURL("http://localhost:8080")
+            .acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+            .acceptEncodingHeader("gzip, deflate")
+            .acceptLanguageHeader("en-US,en;q=0.5")
+            .userAgentHeader("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:16.0) Gecko/20100101 Firefox/16.0")
+
+    val scn = scenario("Default Booking Scenario")
+            // Home Page
+            .exec(http("get_events").get("/rs/api/events"))
+            .pause(5)
+            // First Event selected
+            // TODO WS connection
+            .exec(http("get_events").get("/rs/api/events"))
+            .exec(http("get_venue").get("/rs/api/events/1/venue"))
+            .exec(http("get_sectors").get("/rs/api/venues/1/sectors"))
+            .exec(http("get_bookings").get("/bookings?eventId=1"))
+            .pause(10)
+            // Book selected tickets
+            .exec(http("booking_request")
+                    .post("/bookings")
+                    .body(StringBody("""{"eventId": 1, "sectorId": 1, "positions": [1, 2, 3, 4, 5]}""")).asJSON)
+
+    setUp(scn.inject(atOnceUsers(1)).protocols(httpConf))
+}

--- a/src/test/scala/adele/Stomp.scala
+++ b/src/test/scala/adele/Stomp.scala
@@ -1,0 +1,27 @@
+package adele
+
+import io.gatling.core.Predef.DurationInteger
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+object Stomp {
+
+    val StompConnect = "CONNECT\n" +
+            "accept-version:1.1,1.0\n" +
+            "heart-beat:10000,10000\n" +
+            "\n" +
+            "\u0000"
+
+    val StompConnectCheck = wsListen
+            .within(new DurationInteger(5).seconds)
+            .until(1)
+            .regex("CONNECTED")
+            .saveAs("connection-response")
+
+    val StompSubscribe = "SUBSCRIBE\n" +
+            "id:sub-0\n" +
+            "destination:/topic/tickets\n" +
+            "\n" +
+            "\u0000"
+
+}


### PR DESCRIPTION
This PR is about the basic booking flow:
1. User lands on the home page
2. Goes into the first event's booking page
3. Selects several tickets (2-5 randomly)
4. Clicks on the "Send booking request" button

- [x] Randomize positions
- [x] Randomize sectors
- [x] Add WebSocket connection
- [x] Store already booked positions
- [x] Don't request already booked tickets
- [x] Save bookingId in Session